### PR TITLE
Using volume flow index as trend instead of SMA

### DIFF
--- a/user_data/strategies/MultiRSIVfi.py
+++ b/user_data/strategies/MultiRSIVfi.py
@@ -1,0 +1,86 @@
+# --- Do not remove these libs ---
+from freqtrade.strategy.interface import IStrategy
+from pandas import DataFrame
+# --------------------------------
+from technical.util import resample_to_interval
+from technical.util import resampled_merge
+import talib.abstract as ta
+from technical.indicators import cmf
+from technical.indicators import osc
+from technical.indicators import vfi
+
+
+class MultiRsiVfi(IStrategy):
+    """
+
+    author@: Gert Wohlgemuth
+
+    based on work from Creslin
+
+    """
+    minimal_roi = {
+        "0": 0.01
+    }
+
+    # Optimal stoploss designed for the strategy
+    stoploss = -0.05
+
+    # Optimal ticker interval for the strategy
+    ticker_interval = '15m'
+
+    def get_ticker_indicator(self):
+        return int(self.ticker_interval[:-1])
+
+    def populate_indicators(self, dataframe: DataFrame) -> DataFrame:
+        dataframe['sma5'] = ta.SMA(dataframe, timeperiod=5)
+        dataframe['sma200'] = ta.SMA(dataframe, timeperiod=200)
+
+        # resample our dataframes
+        dataframe_short = resample_to_interval(dataframe, self.get_ticker_indicator() * 2)
+        dataframe_long = resample_to_interval(dataframe, self.get_ticker_indicator() * 8)
+
+        # compute our RSI's
+        dataframe_short['rsi'] = ta.RSI(dataframe_short, timeperiod=14)
+        dataframe_long['rsi'] = ta.RSI(dataframe_long, timeperiod=14)
+        dataframe_short['cmf'] = cmf(dataframe_short, 14)
+        dataframe_long['cmf'] = cmf(dataframe_long, 14)
+
+        dataframe_short['osc'] = osc(dataframe_short, 14)
+        dataframe_long['osc'] = osc(dataframe_long, 14)
+
+        # merge dataframe back together
+        dataframe = resampled_merge(dataframe, dataframe_short)
+        dataframe = resampled_merge(dataframe, dataframe_long)
+
+        dataframe['rsi'] = ta.RSI(dataframe, timeperiod=14)
+
+        # fill NA values with previes
+        dataframe.fillna(method='ffill', inplace=True)
+
+        # Volume Flow Index: Add VFI, VFIMA, Histogram to DF
+        dataframe['vfi'], dataframe['vfima'], dataframe['vfi_hist'] =  \
+            vfi(dataframe, length=130, coef=0.2, vcoef=2.5, signalLength=5, smoothVFI=True)
+
+        return dataframe
+
+    def populate_buy_trend(self, dataframe: DataFrame) -> DataFrame:
+        dataframe.loc[
+            (
+                # must be bearish
+                    #(dataframe['sma5'] >= dataframe['sma200']) &
+                    (dataframe['vfi'] >= dataframe['vfima']) &
+                    (dataframe['rsi'] < (dataframe['resample_{}_rsi'.format(self.get_ticker_indicator() * 8)] - 20)) &
+                    (dataframe['resample_{}_cmf'.format(self.get_ticker_indicator() * 8)] > 0)
+            ),
+            'buy'] = 1
+        return dataframe
+
+    def populate_sell_trend(self, dataframe: DataFrame) -> DataFrame:
+        dataframe.loc[
+            (
+                    (dataframe['vfi'] < dataframe['vfima']) &
+                    (dataframe['rsi'] > dataframe['resample_{}_rsi'.format(self.get_ticker_indicator() * 2)]) &
+                    (dataframe['rsi'] > dataframe['resample_{}_rsi'.format(self.get_ticker_indicator() * 8)])
+            ),
+            'sell'] = 1
+        return dataframe


### PR DESCRIPTION
 Volume Flow Indicator conversion

    Author: creslinux, June 2018 - Python
    Original Author: Chris Moody, TradingView - Pinescript
    To return vfi, vfima and histogram

    A simplified interpretation of the VFI is:
    * Values above zero indicate a bullish state and the crossing of the zero line is the trigger or buy signal.
    * The strongest signal with all money flow indicators is of course divergence.
    * A crossover of vfi > vfima is uptrend
    * A crossunder of vfima > vfi is downtrend
    * smoothVFI can be set to smooth for a cleaner plot to ease false signals
    * histogram can be used against self -1 to check if upward or downward momentum


    Call from strategy to populate vfi, vfima, vfi_hist into dataframe

    Example how to call:
    # Volume Flow Index: Add VFI, VFIMA, Histogram to DF
    dataframe['vfi'], dataframe['vfima'], dataframe['vfi_hist'] =  \
        vfi(dataframe, length=130, coef=0.2, vcoef=2.5, signalLength=5, smoothVFI=False)

    :param dataframe:
    :param length: - VFI Length - 130 default
    :param coef:  - price coef  - 0.2 default
    :param vcoef: - volume coef  - 2.5 default
    :param signalLength: - 5 default
    :param smoothVFI:  bool - False detault
    :return: vfi, vfima, vfi_hist
    """
